### PR TITLE
Refactor card into modular components with config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "agarwal-card",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^0.544.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2884,6 +2885,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lucide-react": "^0.544.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,128 +1,52 @@
 import React, { useMemo } from "react";
-import { Phone, MessageCircle, MapPin, Instagram, Download, ShoppingBag, Clock, Share2, Mail, Globe } from "lucide-react";
-
-// Single–file React component for a QR / Digital Visiting Card landing page
-// ✅ Tailwind CSS classes used throughout
-// ✅ Works in a standard Vite + React project
-// ✅ Includes: vCard download, Web Share API, JSON‑LD for SEO
-// 👉 Update the SHOP object with your real details
-
-const SHOP = {
-  brand: "Agarwal & Company",
-  owner: "Agarwal & Company",
-  phoneDisplay: "+91 98283 94600",
-  phone: "+919828394600", // full digits, for tel:/vCard
-  whatsapp: "919828394600", // numeric for wa.me
-  email: "", // optional ("" to hide)
-  addressLine: "Agarwal and Company, Nala Bazar Rd, Dargah Bazar, Ajmer, Rajasthan 305001",
-  mapLink: "https://maps.app.goo.gl/eNPcbAJUExZCG5hi8",
-  instagram: "https://www.instagram.com/agarwal_kurta_payjama?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
-  website: "", // optional; if blank, Instagram will be used in share/SEO URL
-  hours: [
-    { d: "Mon–Sat", h: "11:00 AM – 9:00 PM" },
-    { d: "Sunday", h: "11:00 AM – 7:00 PM" },
-  ],
-  catalog: [
-    { name: "Kurtas & Sets", href: "#", note: "Cotton • Silk • Festive" },
-    { name: "Sherwanis", href: "#", note: "Wedding • Reception" },
-    { name: "Nehru Jackets", href: "#", note: "Solid • Brocade" },
-    { name: "Pathani Sets", href: "#", note: "Classic • Comfortable" },
-    { name: "Jodhpuri Suits", href: "#", note: "Bandhgala • Formal" },
-  ],
-};
+import { ActionButtons } from "./components/ActionButtons";
+import { AppFooter } from "./components/AppFooter";
+import { HighlightsSection } from "./components/HighlightsSection";
+import { InfoCards } from "./components/InfoCards";
+import { ShopHeader } from "./components/ShopHeader";
+import { StickyBar } from "./components/StickyBar";
+import { shopConfig } from "./config/shopConfig";
+import {
+  buildJsonLd,
+  createMotifBackground,
+  createVCardDownload,
+  getInitials,
+  getShareUrl,
+} from "./utils/shopUtils";
 
 export default function App() {
-  const initials = useMemo(() => {
-    const words = SHOP.brand.split(/\s+/).filter(Boolean);
-    const pick = words.filter(w => /[A-Za-z]/.test(w)).slice(0, 2);
-    return pick.map(w => w[0]).join("").toUpperCase();
-  }, []);
+  const shareUrl = useMemo(() => getShareUrl(shopConfig.links), []);
+  const effectiveShareUrl = shareUrl || (typeof window !== "undefined" ? window.location.href : "");
+  const initials = useMemo(() => getInitials(shopConfig.brand), []);
+  const backgroundImage = useMemo(() => createMotifBackground(), []);
+  const jsonLd = useMemo(() => buildJsonLd(shopConfig, effectiveShareUrl), [effectiveShareUrl]);
 
-  // Subtle Indian motif background (inline SVG -> data URL)
-  const bgUrl = useMemo(() => {
-    const svg = encodeURIComponent(`
-      <svg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'>
-        <defs>
-          <radialGradient id='rg' cx='50%' cy='40%' r='75%'>
-            <stop offset='0%' stop-color='#ffffff'/>
-            <stop offset='100%' stop-color='#fff1e6'/>
-          </radialGradient>
-        </defs>
-        <rect width='160' height='160' fill='url(#rg)'/>
-        <g fill='none' stroke='#f2d3a0' stroke-width='0.6' opacity='0.6'>
-          <path d='M80 10c15 10 25 25 25 40s-10 30-25 40c-15-10-25-25-25-40s10-30 25-40z' />
-          <circle cx='80' cy='80' r='55' />
-          <path d='M15 80h130M80 15v130' opacity='0.25'/>
-        </g>
-      </svg>
-    `);
-    return `url("data:image/svg+xml,${svg}")`;
-  }, []);
-
-  const shareUrl = SHOP.website || SHOP.instagram || (typeof window !== "undefined" ? window.location.href : "");
-
-  // Schema.org JSON‑LD (LocalBusiness / ClothingStore)
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": ["LocalBusiness", "ClothingStore"],
-    name: SHOP.brand,
-    url: shareUrl || undefined,
-    telephone: SHOP.phone.replace(/\+/g, ""),
-    email: SHOP.email || undefined,
-    address: {
-      "@type": "PostalAddress",
-      streetAddress: "Nala Bazar Rd, Dargah Bazar",
-      addressLocality: "Ajmer",
-      addressRegion: "Rajasthan",
-      postalCode: "305001",
-      addressCountry: "IN",
-    },
-    sameAs: [SHOP.instagram].filter(Boolean),
-    openingHours: SHOP.hours.map(h => `${h.d} ${h.h}`),
+  const handleSaveContact = () => {
+    createVCardDownload(shopConfig, effectiveShareUrl);
   };
 
-  const onSaveVCard = () => {
-    const vcard = [
-      "BEGIN:VCARD",
-      "VERSION:3.0",
-      `N:${SHOP.owner};;;`,
-      `FN:${SHOP.brand}`,
-      `ORG:${SHOP.brand}`,
-      `TEL;TYPE=CELL:${SHOP.phone}`,
-      SHOP.email ? `EMAIL;TYPE=work:${SHOP.email}` : null,
-      shareUrl ? `URL:${shareUrl}` : null,
-      `ADR;TYPE=WORK:;;${SHOP.addressLine};;;;`,
-      "END:VCARD",
-    ].filter(Boolean).join("\n");
+  const handleShare = async () => {
+    if (!effectiveShareUrl) {
+      return;
+    }
 
-    const blob = new Blob([vcard], { type: "text/vcard;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${SHOP.brand.toLowerCase().replace(/[^a-z0-9]+/g, "-")}.vcf`;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-  };
-
-  const onShare = async () => {
     const data = {
-      title: SHOP.brand,
-      text: "Men's ethnic wear in Ajmer — tap to view contact & directions",
-      url: shareUrl,
+      title: shopConfig.brand,
+      text: shopConfig.messaging.shareText,
+      url: effectiveShareUrl,
     };
+
     try {
-      if (navigator.share) {
+      if (typeof navigator !== "undefined" && navigator.share) {
         await navigator.share(data);
-      } else if (navigator.clipboard) {
-        await navigator.clipboard.writeText(shareUrl);
+      } else if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(effectiveShareUrl);
         alert("Link copied to clipboard!");
-      } else {
-        window.open(shareUrl, "_blank");
+      } else if (typeof window !== "undefined") {
+        window.open(effectiveShareUrl, "_blank");
       }
-    } catch (_) {
-      // user cancelled share — ignore
+    } catch (error) {
+      console.error("Share failed", error);
     }
   };
 
@@ -130,141 +54,42 @@ export default function App() {
     <div className="min-h-screen bg-gradient-to-br from-[#fff8ee] via-[#fff3e0] to-[#fde6e6] text-stone-800">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
 
-      {/* Header / Brand */}
-      <div className="relative isolate">
-        <div className="absolute inset-0 opacity-70" style={{ backgroundImage: bgUrl }} />
-        <header className="relative mx-auto max-w-xl px-5 pt-10 pb-6 text-center">
-          <div className="mx-auto h-24 w-24 rounded-2xl bg-gradient-to-br from-amber-500 to-rose-600 shadow-lg grid place-items-center">
-            <span className="text-3xl font-black tracking-widest text-white drop-shadow">{initials}</span>
-          </div>
-          <h1 className="mt-4 text-3xl font-bold tracking-tight text-stone-900">{SHOP.brand}</h1>
-          <p className="mt-1 text-sm text-stone-600">Men's ethnic wear • Ajmer</p>
+      <ShopHeader
+        brand={shopConfig.brand}
+        description={shopConfig.description}
+        address={shopConfig.location.fullAddress}
+        mapLink={shopConfig.links.map}
+        initials={initials}
+        backgroundImage={backgroundImage}
+        onShare={handleShare}
+      />
 
-          <div className="mt-4 flex items-center justify-center gap-2 text-xs text-stone-700">
-            <MapPin size={16} className="shrink-0" />
-            <button className="underline decoration-dotted hover:opacity-80" onClick={() => window.open(SHOP.mapLink, "_blank")}>{SHOP.addressLine}</button>
-          </div>
+      <ActionButtons
+        whatsapp={shopConfig.contact.whatsapp}
+        whatsappMessage={shopConfig.messaging.whatsappCta}
+        phone={shopConfig.contact.phone}
+        phoneDisplay={shopConfig.contact.phoneDisplay}
+        mapLink={shopConfig.links.map}
+        onSaveContact={handleSaveContact}
+      />
 
-          <button onClick={onShare} className="absolute right-4 top-4 inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-1.5 text-xs shadow hover:bg-white">
-            <Share2 size={14} /> Share
-          </button>
-        </header>
-      </div>
+      <HighlightsSection catalog={shopConfig.catalog} instagram={shopConfig.links.instagram} />
 
-      {/* Primary CTA buttons */}
-      <section className="mx-auto mt-1 max-w-xl px-5">
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <a href={`https://wa.me/${SHOP.whatsapp}?text=${encodeURIComponent("Hi! Saw your QR card — looking for men's ethnic wear.")}`} target="_blank" rel="noreferrer" className="group rounded-2xl bg-white p-4 shadow hover:shadow-md">
-            <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 group-hover:scale-105 transition">
-              <MessageCircle className="" />
-            </div>
-            <p className="mt-2 text-center text-sm font-semibold">WhatsApp</p>
-          </a>
-          <a href={`tel:${SHOP.phone}`} className="group rounded-2xl bg-white p-4 shadow hover:shadow-md">
-            <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-rose-100 group-hover:scale-105 transition">
-              <Phone />
-            </div>
-            <p className="mt-2 text-center text-sm font-semibold">Call {SHOP.phoneDisplay}</p>
-          </a>
-          <a href={SHOP.mapLink} target="_blank" rel="noreferrer" className="group rounded-2xl bg-white p-4 shadow hover:shadow-md">
-            <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 group-hover:scale-105 transition">
-              <MapPin />
-            </div>
-            <p className="mt-2 text-center text-sm font-semibold">Directions</p>
-          </a>
-          <button onClick={onSaveVCard} className="group rounded-2xl bg-white p-4 shadow hover:shadow-md">
-            <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-violet-100 group-hover:scale-105 transition">
-              <Download />
-            </div>
-            <p className="mt-2 text-center text-sm font-semibold">Save Contact</p>
-          </button>
-        </div>
-      </section>
+      <InfoCards
+        hours={shopConfig.hours}
+        location={shopConfig.location}
+        mapLink={shopConfig.links.map}
+        contact={shopConfig.contact}
+        links={shopConfig.links}
+      />
 
-      {/* Catalog / Highlights */}
-      <section className="mx-auto max-w-xl px-5 mt-8">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Shop Highlights</h2>
-          <a href={SHOP.instagram} target="_blank" rel="noreferrer" className="text-sm inline-flex items-center gap-1 underline decoration-dotted">
-            <Instagram size={16} /> Instagram
-          </a>
-        </div>
-        <div className="mt-3 grid grid-cols-2 gap-3">
-          {SHOP.catalog.map((c, idx) => (
-            <a key={idx} href={c.href} className="relative overflow-hidden rounded-2xl bg-white p-4 shadow hover:shadow-md">
-              <div className="absolute -right-6 -top-6 h-20 w-20 rounded-full bg-gradient-to-br from-amber-300 to-rose-300 opacity-40"/>
-              <ShoppingBag className="" />
-              <p className="mt-2 text-sm font-semibold">{c.name}</p>
-              <p className="text-xs text-stone-600">{c.note}</p>
-            </a>
-          ))}
-        </div>
-      </section>
+      <AppFooter brand={shopConfig.brand} />
 
-      {/* Info cards */}
-      <section className="mx-auto max-w-xl px-5 mt-8 grid gap-3">
-        <div className="rounded-2xl bg-white p-4 shadow">
-          <div className="flex items-start gap-3">
-            <Clock className="mt-0.5" />
-            <div>
-              <p className="font-semibold">Store Hours</p>
-              <ul className="mt-1 text-sm text-stone-700">
-                {SHOP.hours.map((row, i) => (
-                  <li key={i} className="flex justify-between"><span>{row.d}</span><span>{row.h}</span></li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        </div>
-
-        <div className="rounded-2xl bg-white p-4 shadow">
-          <div className="flex items-start gap-3">
-            <MapPin className="mt-0.5" />
-            <div>
-              <p className="font-semibold">Find Us</p>
-              <p className="mt-1 text-sm text-stone-700">{SHOP.addressLine}</p>
-              <div className="mt-2 flex flex-wrap gap-2 text-sm">
-                <a href={SHOP.mapLink} target="_blank" rel="noreferrer" className="rounded-full bg-stone-900 px-3 py-1.5 text-white hover:opacity-90">Open in Maps</a>
-                <button onClick={() => { navigator.clipboard.writeText(SHOP.addressLine); }} className="rounded-full bg-stone-100 px-3 py-1.5 hover:bg-stone-200">Copy address</button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="rounded-2xl bg-white p-4 shadow">
-          <div className="flex flex-wrap items-center gap-3 text-sm">
-            {SHOP.email && (
-              <a className="inline-flex items-center gap-2 hover:opacity-80" href={`mailto:${SHOP.email}`}><Mail size={16}/> {SHOP.email}</a>
-            )}
-            {SHOP.email && <span className="text-stone-400">•</span>}
-            {(SHOP.website || SHOP.instagram) && (
-              <a className="inline-flex items-center gap-2 hover:opacity-80" href={(SHOP.website || SHOP.instagram)} target="_blank" rel="noreferrer"><Globe size={16}/> Website</a>
-            )}
-            {(SHOP.website || SHOP.instagram) && <span className="text-stone-400">•</span>}
-            <a className="inline-flex items-center gap-2 hover:opacity-80" href={`https://wa.me/${SHOP.whatsapp}`} target="_blank" rel="noreferrer"><MessageCircle size={16}/> WhatsApp</a>
-          </div>
-        </div>
-      </section>
-
-      {/* Footer */}
-      <footer className="mx-auto max-w-xl px-5 py-10 text-center text-xs text-stone-500">
-        <p>© {new Date().getFullYear()} {SHOP.brand}. All rights reserved.</p>
-        <p className="mt-1">Crafted for QR visits • Built with ❤️</p>
-      </footer>
-
-      {/* Sticky bar (mobile) */}
-      <div className="fixed inset-x-0 bottom-0 z-50 mx-auto max-w-xl px-4 pb-4">
-        <div className="rounded-2xl bg-stone-900/95 backdrop-blur supports-[backdrop-filter]:bg-stone-900/80 text-white shadow-lg">
-          <div className="grid grid-cols-2 divide-x divide-white/10">
-            <button onClick={onSaveVCard} className="flex items-center justify-center gap-2 py-3 hover:bg-white/5">
-              <Download size={18}/> <span className="text-sm font-semibold">Save Contact</span>
-            </button>
-            <a href={`https://wa.me/${SHOP.whatsapp}?text=${encodeURIComponent("Hi! Need details about your men's collection.")}`} target="_blank" rel="noreferrer" className="flex items-center justify-center gap-2 py-3 hover:bg-white/5">
-              <MessageCircle size={18}/> <span className="text-sm font-semibold">WhatsApp</span>
-            </a>
-          </div>
-        </div>
-      </div>
+      <StickyBar
+        whatsapp={shopConfig.contact.whatsapp}
+        whatsappMessage={shopConfig.messaging.whatsappSticky}
+        onSaveContact={handleSaveContact}
+      />
     </div>
   );
 }

--- a/src/components/ActionButtons.jsx
+++ b/src/components/ActionButtons.jsx
@@ -1,0 +1,68 @@
+import { Download, MapPin, MessageCircle, Phone } from "lucide-react";
+import { buildWhatsAppLink } from "../utils/shopUtils";
+
+export function ActionButtons({
+  whatsapp,
+  whatsappMessage,
+  phone,
+  phoneDisplay,
+  mapLink,
+  onSaveContact,
+}) {
+  const whatsappLink = buildWhatsAppLink(whatsapp, whatsappMessage);
+
+  const whatsappCard = whatsappLink ? (
+    <a
+      href={whatsappLink}
+      target="_blank"
+      rel="noreferrer"
+      className="group rounded-2xl bg-white p-4 shadow hover:shadow-md"
+    >
+      <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 transition group-hover:scale-105">
+        <MessageCircle />
+      </div>
+      <p className="mt-2 text-center text-sm font-semibold">WhatsApp</p>
+    </a>
+  ) : (
+    <div className="rounded-2xl bg-white p-4 shadow opacity-60">
+      <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100">
+        <MessageCircle />
+      </div>
+      <p className="mt-2 text-center text-sm font-semibold">WhatsApp</p>
+    </div>
+  );
+
+  return (
+    <section className="mx-auto mt-1 max-w-xl px-5">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {whatsappCard}
+
+        <a href={`tel:${phone}`} className="group rounded-2xl bg-white p-4 shadow hover:shadow-md">
+          <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-rose-100 transition group-hover:scale-105">
+            <Phone />
+          </div>
+          <p className="mt-2 text-center text-sm font-semibold">Call {phoneDisplay}</p>
+        </a>
+
+        <a
+          href={mapLink}
+          target="_blank"
+          rel="noreferrer"
+          className="group rounded-2xl bg-white p-4 shadow hover:shadow-md"
+        >
+          <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 transition group-hover:scale-105">
+            <MapPin />
+          </div>
+          <p className="mt-2 text-center text-sm font-semibold">Directions</p>
+        </a>
+
+        <button type="button" onClick={onSaveContact} className="group rounded-2xl bg-white p-4 shadow hover:shadow-md">
+          <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-violet-100 transition group-hover:scale-105">
+            <Download />
+          </div>
+          <p className="mt-2 text-center text-sm font-semibold">Save Contact</p>
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/AppFooter.jsx
+++ b/src/components/AppFooter.jsx
@@ -1,0 +1,8 @@
+export function AppFooter({ brand }) {
+  return (
+    <footer className="mx-auto max-w-xl px-5 py-10 text-center text-xs text-stone-500">
+      <p>© {new Date().getFullYear()} {brand}. All rights reserved.</p>
+      <p className="mt-1">Crafted for QR visits • Built with ❤️</p>
+    </footer>
+  );
+}

--- a/src/components/HighlightsSection.jsx
+++ b/src/components/HighlightsSection.jsx
@@ -1,0 +1,39 @@
+import { Instagram, ShoppingBag } from "lucide-react";
+
+export function HighlightsSection({ catalog, instagram }) {
+  if (!catalog?.length) {
+    return null;
+  }
+
+  return (
+    <section className="mx-auto mt-8 max-w-xl px-5">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Shop Highlights</h2>
+        {instagram && (
+          <a
+            href={instagram}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-sm underline decoration-dotted"
+          >
+            <Instagram size={16} /> Instagram
+          </a>
+        )}
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-3">
+        {catalog.map((item, idx) => (
+          <a
+            key={`${item.name}-${idx}`}
+            href={item.href}
+            className="relative overflow-hidden rounded-2xl bg-white p-4 shadow hover:shadow-md"
+          >
+            <div className="absolute -right-6 -top-6 h-20 w-20 rounded-full bg-gradient-to-br from-amber-300 to-rose-300 opacity-40" />
+            <ShoppingBag />
+            <p className="mt-2 text-sm font-semibold">{item.name}</p>
+            <p className="text-xs text-stone-600">{item.note}</p>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/InfoCards.jsx
+++ b/src/components/InfoCards.jsx
@@ -1,0 +1,135 @@
+import { Fragment } from "react";
+import { Clock, Globe, Mail, MapPin, MessageCircle } from "lucide-react";
+import { buildWhatsAppLink } from "../utils/shopUtils";
+
+export function InfoCards({
+  hours = [],
+  location = {},
+  mapLink,
+  contact = {},
+  links = {},
+}) {
+  const handleCopyAddress = async () => {
+    if (!location.fullAddress) {
+      return;
+    }
+
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(location.fullAddress);
+        alert("Address copied to clipboard!");
+      }
+    } catch (error) {
+      console.error("Unable to copy address", error);
+    }
+  };
+
+  const websiteUrl = links.website || links.instagram;
+  const websiteLabel = links.website ? "Website" : "Instagram";
+  const whatsappLink = buildWhatsAppLink(contact.whatsapp);
+  const contactItems = [];
+
+  if (contact.email) {
+    contactItems.push({
+      key: "email",
+      element: (
+        <a className="inline-flex items-center gap-2 hover:opacity-80" href={`mailto:${contact.email}`}>
+          <Mail size={16} /> {contact.email}
+        </a>
+      ),
+    });
+  }
+
+  if (websiteUrl) {
+    contactItems.push({
+      key: "website",
+      element: (
+        <a
+          className="inline-flex items-center gap-2 hover:opacity-80"
+          href={websiteUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <Globe size={16} /> {websiteLabel}
+        </a>
+      ),
+    });
+  }
+
+  if (whatsappLink) {
+    contactItems.push({
+      key: "whatsapp",
+      element: (
+        <a
+          className="inline-flex items-center gap-2 hover:opacity-80"
+          href={whatsappLink}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <MessageCircle size={16} /> WhatsApp
+        </a>
+      ),
+    });
+  }
+
+  return (
+    <section className="mx-auto mt-8 grid max-w-xl gap-3 px-5">
+      <div className="rounded-2xl bg-white p-4 shadow">
+        <div className="flex items-start gap-3">
+          <Clock className="mt-0.5" />
+          <div>
+            <p className="font-semibold">Store Hours</p>
+            <ul className="mt-1 text-sm text-stone-700">
+              {hours.map(({ days, time }) => (
+                <li key={`${days}-${time}`} className="flex justify-between">
+                  <span>{days}</span>
+                  <span>{time}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-2xl bg-white p-4 shadow">
+        <div className="flex items-start gap-3">
+          <MapPin className="mt-0.5" />
+          <div>
+            <p className="font-semibold">Find Us</p>
+            <p className="mt-1 text-sm text-stone-700">{location.fullAddress}</p>
+            <div className="mt-2 flex flex-wrap gap-2 text-sm">
+              <a
+                href={mapLink}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-full bg-stone-900 px-3 py-1.5 text-white hover:opacity-90"
+              >
+                Open in Maps
+              </a>
+              <button
+                type="button"
+                onClick={handleCopyAddress}
+                className="rounded-full bg-stone-100 px-3 py-1.5 hover:bg-stone-200"
+              >
+                Copy address
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {contactItems.length > 0 && (
+        <div className="rounded-2xl bg-white p-4 shadow">
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            {contactItems.map((item, index) => (
+              <Fragment key={item.key}>
+                {index > 0 && <span className="text-stone-400">•</span>}
+                {item.element}
+              </Fragment>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/ShopHeader.jsx
+++ b/src/components/ShopHeader.jsx
@@ -1,0 +1,44 @@
+import { MapPin, Share2 } from "lucide-react";
+
+export function ShopHeader({
+  brand,
+  description,
+  address,
+  mapLink,
+  initials,
+  backgroundImage,
+  onShare,
+}) {
+  return (
+    <div className="relative isolate">
+      <div className="absolute inset-0 opacity-70" style={{ backgroundImage }} />
+      <header className="relative mx-auto max-w-xl px-5 pt-10 pb-6 text-center">
+        <div className="mx-auto grid h-24 w-24 place-items-center rounded-2xl bg-gradient-to-br from-amber-500 to-rose-600 shadow-lg">
+          <span className="text-3xl font-black tracking-widest text-white drop-shadow">{initials}</span>
+        </div>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight text-stone-900">{brand}</h1>
+        <p className="mt-1 text-sm text-stone-600">{description}</p>
+
+        <div className="mt-4 flex items-center justify-center gap-2 text-xs text-stone-700">
+          <MapPin size={16} className="shrink-0" />
+          <a
+            className="underline decoration-dotted hover:opacity-80"
+            href={mapLink}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {address}
+          </a>
+        </div>
+
+        <button
+          type="button"
+          onClick={onShare}
+          className="absolute right-4 top-4 inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-1.5 text-xs shadow hover:bg-white"
+        >
+          <Share2 size={14} /> Share
+        </button>
+      </header>
+    </div>
+  );
+}

--- a/src/components/StickyBar.jsx
+++ b/src/components/StickyBar.jsx
@@ -1,0 +1,40 @@
+import { Download, MessageCircle } from "lucide-react";
+import { buildWhatsAppLink } from "../utils/shopUtils";
+
+export function StickyBar({ whatsapp, whatsappMessage, onSaveContact }) {
+  const whatsappLink = buildWhatsAppLink(whatsapp, whatsappMessage);
+  const whatsappAction = whatsappLink ? (
+    <a
+      href={whatsappLink}
+      target="_blank"
+      rel="noreferrer"
+      className="flex items-center justify-center gap-2 py-3 hover:bg-white/5"
+    >
+      <MessageCircle size={18} />
+      <span className="text-sm font-semibold">WhatsApp</span>
+    </a>
+  ) : (
+    <span className="flex items-center justify-center gap-2 py-3 text-white/70">
+      <MessageCircle size={18} />
+      <span className="text-sm font-semibold">WhatsApp</span>
+    </span>
+  );
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 mx-auto max-w-xl px-4 pb-4">
+      <div className="rounded-2xl bg-stone-900/95 text-white shadow-lg backdrop-blur supports-[backdrop-filter]:bg-stone-900/80">
+        <div className="grid grid-cols-2 divide-x divide-white/10">
+          <button
+            type="button"
+            onClick={onSaveContact}
+            className="flex items-center justify-center gap-2 py-3 hover:bg-white/5"
+          >
+            <Download size={18} />
+            <span className="text-sm font-semibold">Save Contact</span>
+          </button>
+          {whatsappAction}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/config/shopConfig.js
+++ b/src/config/shopConfig.js
@@ -1,0 +1,41 @@
+export const shopConfig = {
+  brand: "Agarwal & Company",
+  owner: "Agarwal & Company",
+  description: "Men's ethnic wear • Ajmer",
+  contact: {
+    phoneDisplay: "+91 98283 94600",
+    phone: "+919828394600",
+    whatsapp: "919828394600",
+    email: "",
+  },
+  links: {
+    map: "https://maps.app.goo.gl/eNPcbAJUExZCG5hi8",
+    instagram:
+      "https://www.instagram.com/agarwal_kurta_payjama?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
+    website: "",
+  },
+  location: {
+    fullAddress: "Agarwal and Company, Nala Bazar Rd, Dargah Bazar, Ajmer, Rajasthan 305001",
+    streetAddress: "Nala Bazar Rd, Dargah Bazar",
+    locality: "Ajmer",
+    region: "Rajasthan",
+    postalCode: "305001",
+    countryCode: "IN",
+  },
+  hours: [
+    { days: "Mon–Sat", time: "11:00 AM – 9:00 PM" },
+    { days: "Sunday", time: "11:00 AM – 7:00 PM" },
+  ],
+  catalog: [
+    { name: "Kurtas & Sets", href: "#", note: "Cotton • Silk • Festive" },
+    { name: "Sherwanis", href: "#", note: "Wedding • Reception" },
+    { name: "Nehru Jackets", href: "#", note: "Solid • Brocade" },
+    { name: "Pathani Sets", href: "#", note: "Classic • Comfortable" },
+    { name: "Jodhpuri Suits", href: "#", note: "Bandhgala • Formal" },
+  ],
+  messaging: {
+    shareText: "Men's ethnic wear in Ajmer — tap to view contact & directions",
+    whatsappCta: "Hi! Saw your QR card — looking for men's ethnic wear.",
+    whatsappSticky: "Hi! Need details about your men's collection.",
+  },
+};

--- a/src/utils/shopUtils.js
+++ b/src/utils/shopUtils.js
@@ -1,0 +1,118 @@
+export const getInitials = (brand = "") => {
+  const words = brand.split(/\s+/).filter(Boolean);
+  const pick = words.filter(word => /[A-Za-z]/.test(word)).slice(0, 2);
+  return pick.map(word => word[0]).join("").toUpperCase();
+};
+
+export const createMotifBackground = () => {
+  const svg = encodeURIComponent(`
+    <svg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'>
+      <defs>
+        <radialGradient id='rg' cx='50%' cy='40%' r='75%'>
+          <stop offset='0%' stop-color='#ffffff'/>
+          <stop offset='100%' stop-color='#fff1e6'/>
+        </radialGradient>
+      </defs>
+      <rect width='160' height='160' fill='url(#rg)'/>
+      <g fill='none' stroke='#f2d3a0' stroke-width='0.6' opacity='0.6'>
+        <path d='M80 10c15 10 25 25 25 40s-10 30-25 40c-15-10-25-25-25-40s10-30 25-40z' />
+        <circle cx='80' cy='80' r='55' />
+        <path d='M15 80h130M80 15v130' opacity='0.25'/>
+      </g>
+    </svg>
+  `);
+  return `url("data:image/svg+xml,${svg}")`;
+};
+
+export const getShareUrl = links => {
+  if (!links) return "";
+  if (links.website) return links.website;
+  if (links.instagram) return links.instagram;
+  if (typeof window !== "undefined") {
+    return window.location.href;
+  }
+  return "";
+};
+
+export const buildJsonLd = (config, shareUrl) => {
+  const {
+    brand,
+    contact,
+    location,
+    links,
+    hours,
+  } = config;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": ["LocalBusiness", "ClothingStore"],
+    name: brand,
+    url: shareUrl || undefined,
+    telephone: contact.phone.replace(/\+/g, ""),
+    email: contact.email || undefined,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: location.streetAddress,
+      addressLocality: location.locality,
+      addressRegion: location.region,
+      postalCode: location.postalCode,
+      addressCountry: location.countryCode,
+    },
+    sameAs: [links.instagram, links.website].filter(Boolean),
+    openingHours: hours.map(({ days, time }) => `${days} ${time}`),
+  };
+};
+
+const sanitizeFileName = text => text.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+
+export const buildVCard = (config, shareUrl) => {
+  const {
+    owner,
+    brand,
+    contact,
+    location,
+  } = config;
+
+  return [
+    "BEGIN:VCARD",
+    "VERSION:3.0",
+    `N:${owner};;;`,
+    `FN:${brand}`,
+    `ORG:${brand}`,
+    `TEL;TYPE=CELL:${contact.phone}`,
+    contact.email ? `EMAIL;TYPE=work:${contact.email}` : null,
+    shareUrl ? `URL:${shareUrl}` : null,
+    `ADR;TYPE=WORK:;;${location.fullAddress};;;;`,
+    "END:VCARD",
+  ]
+    .filter(Boolean)
+    .join("\n");
+};
+
+export const buildWhatsAppLink = (number, message = "") => {
+  if (!number) {
+    return "";
+  }
+
+  const text = message ? encodeURIComponent(message) : "";
+  const query = text ? `?text=${text}` : "";
+  return `https://wa.me/${number}${query}`;
+};
+
+export const downloadTextFile = (content, filename, mimeType = "text/plain") => {
+  const blob = new Blob([content], { type: `${mimeType};charset=utf-8` });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};
+
+export const createVCardDownload = (config, shareUrl) => {
+  const vcard = buildVCard(config, shareUrl);
+  const filename = `${sanitizeFileName(config.brand)}.vcf`;
+  downloadTextFile(vcard, filename, "text/vcard");
+};


### PR DESCRIPTION
## Summary
- move shop content, links, and messaging into a dedicated configuration module for easier updates
- refactor the landing page into reusable components for the header, actions, highlights, info cards, footer, and sticky bar
- add shared utilities for background art, vCard downloads, share handling, and WhatsApp links while declaring the lucide-react dependency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c95bc6693c8320b70a344c292b8802